### PR TITLE
Added check for running as root before running 'apt update'

### DIFF
--- a/widgets/apt
+++ b/widgets/apt
@@ -9,7 +9,9 @@ data='../data/apt'
 [[ -r "${data}" ]] && source "${data}"
 if [[ "${lastupdate}" != "${date}" ]]; then
     source ../tools/colors.sh
-    apt-get -qq update
+    if [[ "${USER}" == "root" ]]; then
+      apt-get -qqq update
+    fi
     pkgs=$(apt -qq list --upgradable 2>/dev/null | wc -l)
     pkgs=$(c_if_r "${pkgs}" '<' '1' 'no new package' "${pkgs} new packages")
     echo "lastupdate=${date}" >  "${data}"


### PR DESCRIPTION
A super simple update which does two things:

- Adds an extra -q to apt update to silence "xx packages can be upgraded." messages.
- Adds a check to make sure the script is running as root before running apt update

This is my first pull request so hopefully it comes through correctly.